### PR TITLE
Fix for ``fight_planks`` being not craftable

### DIFF
--- a/src/main/java/net/bon/soulfulnether/util/SoulfulBlockTags.java
+++ b/src/main/java/net/bon/soulfulnether/util/SoulfulBlockTags.java
@@ -9,7 +9,7 @@ import net.minecraft.util.Identifier;
 
 public final class SoulfulBlockTags {
         public static final TagKey<Block> SOUL_CONVERTING_BLOCKS = createTag("soul_converting_blocks");
-        public static final TagKey<Block> FRIGHT_STEMS = createTag("fright_stems");
+//        public static final TagKey<Block> FRIGHT_STEMS = createTag("fright_stems");
         public static final TagKey<Block> FRIGHT_WART_BLOCKS = createTag("fright_wart_blocks");
         public static final TagKey<Block> LICHOSS = createTag("lichoss");
         public static final TagKey<Block> LICHOSS_REPLACEABLE = createTag("lichoss_replaceable");

--- a/src/main/java/net/bon/soulfulnether/util/SoulfulItemTags.java
+++ b/src/main/java/net/bon/soulfulnether/util/SoulfulItemTags.java
@@ -9,6 +9,7 @@ import net.minecraft.util.Identifier;
 
 public final class SoulfulItemTags {
     public static final TagKey<Item> SOULROOT_FOODS = createTag("soulroot_foods");
+    public static final TagKey<Item> FRIGHT_STEMS = createTag("fright_stems");
 
     private SoulfulItemTags() {
     }

--- a/src/main/resources/data/soulfulnether/tags/blocks/items/fright_stems.json
+++ b/src/main/resources/data/soulfulnether/tags/blocks/items/fright_stems.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "soulfulnether:fright_stem",
+    "soulfulnether:stripped_fright_stem",
+    "soulfulnether:fright_hyphae",
+    "soulfulnether:stripped_fright_hyphae"
+  ]
+}


### PR DESCRIPTION
This fixes the issue where you are unable to craft ``fright_planks``. Commented out the ``Block`` tag incase it's needed later, you can choose to remove if you don't need it.

**Issue**: ``fright_stems`` tag was registered as ``Block`` tag instead of a ``Item`` tag
**Fix**: Changed ``fright_stems`` to be an ``Item`` tag and added the ``tags/items/fright_stems.json`` to define the tag