### PR TITLE
Fix fright planks recipe ingredient and count

### DIFF
--- a/src/main/resources/data/soulfulnether/recipes/fright_planks.json
+++ b/src/main/resources/data/soulfulnether/recipes/fright_planks.json
@@ -4,11 +4,11 @@
   "group": "planks",
   "ingredients": [
     {
-      "tag": "soulfulnether:fright_stems"
+      "tag": "soulfulnether:fright_stem"
     }
   ],
   "result": {
     "item": "soulfulnether:fright_planks",
-    "count": 4
+    "count": 2
   }
 }


### PR DESCRIPTION
The fright_stem contains an s that isn't needed and glitch everything and the count has been make the same than the other stem